### PR TITLE
Drewpc disable height animation

### DIFF
--- a/src/unslider.js
+++ b/src/unslider.js
@@ -29,6 +29,7 @@
 			item: '>li',    // slidable items selector
 			easing: 'swing',// easing function to use for animation
 			autoplay: true  // enable autoplay on initialisation
+			animateHeight: true  // enable variable height animation
 		};
 
 		_.init = function(el, o) {
@@ -174,7 +175,11 @@
 
 			var speed = callback ? 5 : o.speed | 0,
 				easing = o.easing,
-				obj = {height: target.outerHeight()};
+				obj = {};
+
+                        if(o.animateHeight === true) {
+                            obj.height = target.outerHeight();
+                        }
 
 			if (!ul.queue('fx').length) {
 				//  Handle those pesky dots

--- a/src/unslider.js
+++ b/src/unslider.js
@@ -28,7 +28,7 @@
 			items: '>ul',   // slides container selector
 			item: '>li',    // slidable items selector
 			easing: 'swing',// easing function to use for animation
-			autoplay: true  // enable autoplay on initialisation
+			autoplay: true,  // enable autoplay on initialisation
 			animateHeight: true  // enable variable height animation
 		};
 


### PR DESCRIPTION
When animating the transition of slides with different heights, there should be an option to disable the animation of the height change.  This prevents a weird visualization where the slide shifts left/right and up/down at the same time.  In most cases, the animation should just go left/right and not animate the change in height.