### PR TITLE
Call Swipe events on slides not on the container

### DIFF
--- a/src/js/unslider.js
+++ b/src/js/unslider.js
@@ -289,7 +289,7 @@
 		self.initSwipe = function() {
 			var width = self.$slides.width();
 
-			self.$container.on({
+			self.$container.find("li").on({
 				swipeleft: self.next,
 				swiperight: self.prev,
 


### PR DESCRIPTION
Swipe event was not working on my application. Apparently unslider.js is calling the swipeleft and swiperight events on an incorrect DOM object. 
I found in the jquery.event.swipe website that they call the swipe event on the slide itself, not the container (in this case the .unslider-wrap element). Therefore, my fix was just call the events on the "li" elements.