### PR TITLE
Bower version updated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "unslider",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "homepage": "http://unslider.com",
   "authors": [
     "Visual Idiot <iam@visualidiot.com>"


### PR DESCRIPTION
Bower version updated to avoid warning during bower install

    bower unslider#* mismatch Version declared in the json (2.0.1) is different than the resolved one (2.0.3)
 