### PR TITLE
Fixed jQuery.each loop

### DIFF
--- a/src/js/unslider.js
+++ b/src/js/unslider.js
@@ -627,8 +627,8 @@
 
 	//  And set up our jQuery plugin
 	$.fn.unslider = function(opts) {
-		return this.each(function() {
-			var $this = $(this);
+		return this.each(function(index,elem) {
+			var $this = $(elem);
 
 			//  Allow usage of .unslider('function_name')
 			//  as well as using .data('unslider') to access the

--- a/src/js/unslider.js
+++ b/src/js/unslider.js
@@ -629,7 +629,10 @@
 	$.fn.unslider = function(opts) {
 		return this.each(function(index,elem) {
 			var $this = $(elem);
-
+            var unslider = $(elem).data('unslider');
+            if(unslider instanceof $.Unslider) {
+                return;
+            }
 			//  Allow usage of .unslider('function_name')
 			//  as well as using .data('unslider') to access the
 			//  main Unslider object


### PR DESCRIPTION
the code referenced this, but that defeats the purose of using each. prevents double wrapping of elements, and animations to continue when they should stop.